### PR TITLE
Adding a Series column in Games list.

### DIFF
--- a/include/DataStruct.h
+++ b/include/DataStruct.h
@@ -125,7 +125,8 @@ enum class UtilityTableName
     ACTORS,
     PRODUCTION,
     MUSIC,
-    AUTHORS
+    AUTHORS,
+    SERIES
 };
 
 namespace Game

--- a/include/DataStruct.h
+++ b/include/DataStruct.h
@@ -61,6 +61,7 @@ struct GameItem
     long long int gameID;
     long long int gamePos;
     QString name;
+    QString series;
     QString categories;
     QString developpers;
     QString publishers;
@@ -134,13 +135,14 @@ namespace Game
     enum ColumnIndex
     {
         NAME = 0,
-        CATEGORIES = 1,
-        DEVELOPPERS = 2,
-        PUBLISHERS = 3,
-        PLATFORMS = 4,
-        SERVICES = 5,
-        SENSITIVE_CONTENT = 6,
-        RATE = 7
+        SERIES = 1,
+        CATEGORIES = 2,
+        DEVELOPPERS = 3,
+        PUBLISHERS = 4,
+        PLATFORMS = 5,
+        SERVICES = 6,
+        SENSITIVE_CONTENT = 7,
+        RATE = 8
     };
 
     struct SensitiveContentData
@@ -152,6 +154,7 @@ namespace Game
 
     struct SaveUtilityData
     {
+        QList<ItemUtilityData> series;
         QList<ItemUtilityData> categories;
         QList<ItemUtilityData> developpers;
         QList<ItemUtilityData> publishers;
@@ -185,6 +188,7 @@ namespace Game
 
     struct SaveUtilityInterfaceData
     {
+        QList<SaveUtilityInterfaceItem> series;
         QList<SaveUtilityInterfaceItem> categories;
         QList<SaveUtilityInterfaceItem> developpers;
         QList<SaveUtilityInterfaceItem> pubishers;
@@ -196,6 +200,7 @@ namespace Game
     struct ColumnsSize
     {
         int name;
+        int series;
         int categories;
         int developpers;
         int publishers;

--- a/include/SaveInterface.h
+++ b/include/SaveInterface.h
@@ -32,8 +32,8 @@
 
 // Type identifier and version of a GLD file.
 #define GLD_IDENTIFIER "GLD"
-#define GLD_VERSION (int)(500)
-#define GLD_VERSION_MAX_SUPPORT (int)(600)
+#define GLD_VERSION (int)(600)
+#define GLD_VERSION_MAX_SUPPORT (int)(700)
 
 #define MLD_IDENTIFIER "MLD"
 #define MLD_VERSION (int)(100)

--- a/include/SaveInterface.h
+++ b/include/SaveInterface.h
@@ -32,6 +32,8 @@
 
 // Type identifier and version of a GLD file.
 #define GLD_IDENTIFIER "GLD"
+#define GLD_LEGACY_VERSION (int)(500)
+#define GLD_LEGACY_MAX_SUPPORT (int)(600)
 #define GLD_VERSION (int)(600)
 #define GLD_VERSION_MAX_SUPPORT (int)(700)
 
@@ -55,6 +57,8 @@ public:
     static bool save(const QString& filePath, const QVariant& data);
     static bool open(const QString& filePath, QVariant& data);
 
+    static bool isLegacy();
+
 private:
     static bool saveGame(const QString& filePath, const QVariant& data);
     static bool openGame(QDataStream* in, QVariant& data);
@@ -67,6 +71,8 @@ private:
 
     static bool saveBooksList(const QString& filePath, const QVariant& data);
     static bool openBooksList(QDataStream* in, QVariant& data);
+
+    static bool m_isLegacy;
 };
 
 // ItemUtilityData QDataStream operators

--- a/include/SqlUtilityTable.h
+++ b/include/SqlUtilityTable.h
@@ -54,6 +54,7 @@ private:
 	// Games
 	void createGameTables();
 	void destroyGameTables();
+	void createSeriesTable();
 	void createCategoriesTable();
 	void createDeveloppersTable();
 	void createPublishersTable();

--- a/include/TableModelGame.h
+++ b/include/TableModelGame.h
@@ -72,6 +72,8 @@ private:
 
     void queryUtilityField(UtilityTableName tableName);
     void queryUtilityField(UtilityTableName tableName, long long int gameID);
+    void querySeriesField();
+    void querySeriesField(long long int gameID);
     void queryCategoriesField();
     void queryCategoriesField(long long int gameID);
     void queryDeveloppersField();

--- a/src/FilterDialog.cpp
+++ b/src/FilterDialog.cpp
@@ -69,6 +69,7 @@ void FilterDialog::createWidget()
             {
                 "None",
                 "Name",
+                "Series",
                 "Categories",
                 "Developpers",
                 "Publishers",
@@ -206,21 +207,23 @@ void FilterDialog::applyFilter()
             m_model->setFilter(filter);
             accept();
         }
-        else if (m_lastIndex >= 2 && m_lastIndex <= 6)
+        else if (m_lastIndex >= 2 && m_lastIndex <= 7)
         {
             if (!m_utilityView || !m_utilityModel)
                 reject();
 
             int columnID;
             if (m_lastIndex == 2)
-                columnID = Game::CATEGORIES;
+                columnID = Game::SERIES;
             else if (m_lastIndex == 3)
-                columnID = Game::DEVELOPPERS;
+                columnID = Game::CATEGORIES;
             else if (m_lastIndex == 4)
-                columnID = Game::PUBLISHERS;
+                columnID = Game::DEVELOPPERS;
             else if (m_lastIndex == 5)
-                columnID = Game::PLATFORMS;
+                columnID = Game::PUBLISHERS;
             else if (m_lastIndex == 6)
+                columnID = Game::PLATFORMS;
+            else if (m_lastIndex == 7)
                 columnID = Game::SERVICES;
             
             ListFilter filter = {};
@@ -416,18 +419,20 @@ void FilterDialog::comboBoxChanged(int index)
             m_stackedLayout->setCurrentIndex(1);
             m_nameText->clear();
         }
-        else if (index >= 2 && index <= 6)
+        else if (index >= 2 && index <= 7)
         {
             UtilityTableName tableName;
             if (index == 2)
-                tableName = UtilityTableName::CATEGORIES;
+                tableName = UtilityTableName::SERIES;
             else if (index == 3)
-                tableName = UtilityTableName::DEVELOPPERS;
+                tableName = UtilityTableName::CATEGORIES;
             else if (index == 4)
-                tableName = UtilityTableName::PUBLISHERS;
+                tableName = UtilityTableName::DEVELOPPERS;
             else if (index == 5)
-                tableName = UtilityTableName::PLATFORM;
+                tableName = UtilityTableName::PUBLISHERS;
             else if (index == 6)
+                tableName = UtilityTableName::PLATFORM;
+            else if (index == 7)
                 tableName = UtilityTableName::SERVICES;
             
             m_utilityModel = new UtilityInterfaceEditorModel(

--- a/src/GameListView.cpp
+++ b/src/GameListView.cpp
@@ -231,6 +231,7 @@ QVariant GameListView::listData() const
                 // Retrieve the size of the column.
                 Game::SaveDataTable data = qvariant_cast<Game::SaveDataTable>(variant);
                 data.viewColumnsSize.name = m_view->columnWidth(Game::NAME);
+                data.viewColumnsSize.series = m_view->columnWidth(Game::SERIES);
                 data.viewColumnsSize.categories = m_view->columnWidth(Game::CATEGORIES);
                 data.viewColumnsSize.developpers = m_view->columnWidth(Game::DEVELOPPERS);
                 data.viewColumnsSize.publishers = m_view->columnWidth(Game::PUBLISHERS);
@@ -265,6 +266,7 @@ void GameListView::setColumnsSizeAndSortingOrder(const QVariant& variant)
         {
             Game::SaveDataTable data = qvariant_cast<Game::SaveDataTable>(variant);
             m_view->setColumnWidth(Game::NAME, data.viewColumnsSize.name);
+            m_view->setColumnWidth(Game::SERIES, data.viewColumnsSize.series);
             m_view->setColumnWidth(Game::CATEGORIES, data.viewColumnsSize.categories);
             m_view->setColumnWidth(Game::DEVELOPPERS, data.viewColumnsSize.developpers);
             m_view->setColumnWidth(Game::PUBLISHERS, data.viewColumnsSize.publishers);

--- a/src/ListViewDelegate.cpp
+++ b/src/ListViewDelegate.cpp
@@ -181,7 +181,8 @@ QWidget* ListViewDelegate::createEditor(QWidget* parent, const QStyleOptionViewI
 				return editor;
 			}
 		}
-		else if (index.column() == Game::CATEGORIES ||
+		else if (index.column() == Game::SERIES ||
+				 index.column() == Game::CATEGORIES ||
 				 index.column() == Game::DEVELOPPERS ||
 				 index.column() == Game::PUBLISHERS ||
 				 index.column() == Game::PLATFORMS ||
@@ -194,7 +195,9 @@ QWidget* ListViewDelegate::createEditor(QWidget* parent, const QStyleOptionViewI
 			
 			UtilityTableName tableName;
 
-			if (index.column() == Game::CATEGORIES)
+			if (index.column() == Game::SERIES)
+				tableName = UtilityTableName::SERIES;
+			else if (index.column() == Game::CATEGORIES)
 				tableName = UtilityTableName::CATEGORIES;
 			else if (index.column() == Game::DEVELOPPERS)
 				tableName = UtilityTableName::DEVELOPPERS;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -204,6 +204,11 @@ void MainWindow::createGameToolBar()
 	m_utilityMenu = new QMenu(tr("Game Utility"), m_listToolBar);
 	connect(m_utilityMenu, &QMenu::destroyed, [this](){this->m_utilityMenu = nullptr;});
 	reinsertMenu();
+	QAction* serAct = new QAction(tr("Series"), m_listToolBar);
+	serAct->setToolTip(tr("Open the series editor."));
+	connect(serAct, &QAction::triggered, [this](){this->m_tabAndList->openUtility(UtilityTableName::SERIES);});
+	m_utilityMenu->addAction(serAct);
+
 	QAction* catAct = new QAction(tr("Categories"), m_listToolBar);
 	catAct->setToolTip(tr("Open the categories editor."));
 	connect(catAct, &QAction::triggered, [this](){this->m_tabAndList->openUtility(UtilityTableName::CATEGORIES);});

--- a/src/SaveInterface.cpp
+++ b/src/SaveInterface.cpp
@@ -95,6 +95,11 @@ bool SaveInterface::open(const QString& filePath, QVariant& data)
         return false;
 }
 
+bool SaveInterface::isLegacy()
+{
+    return m_isLegacy;
+}
+
 // Item utility data
 QDataStream& operator<<(QDataStream& out, const ItemUtilityData& data)
 {

--- a/src/SaveInterface_Game.cpp
+++ b/src/SaveInterface_Game.cpp
@@ -114,9 +114,14 @@ QDataStream& operator<<(QDataStream& out, const Game::SaveUtilityData& data)
     // Writing the Item SQL Utility data.
     // Categories
     // Writing the number of rows.
-    long long int count = data.categories.size();
+    long long int count = data.series.size();
     out << count;
     // Then writing each row.
+    for (long long int i = 0; i < count; i++)
+        out << data.series.at(i);
+
+    count = data.categories.size();
+    out << count;
     for (long long int i = 0; i < count; i++)
         out << data.categories.at(i);
     
@@ -157,6 +162,14 @@ QDataStream& operator>>(QDataStream& in, Game::SaveUtilityData& data)
     if (count > 0)
     {
         // Then, reading each row.
+        data.series.resize(count);
+        for (long long int i = 0; i < count; i++)
+            in >> data.series[i];
+    }
+
+    in >> count;
+    if (count > 0)
+    {
         data.categories.resize(count);
         for (long long int i = 0; i < count; i++)
             in >> data.categories[i];
@@ -204,8 +217,14 @@ QDataStream& operator>>(QDataStream& in, Game::SaveUtilityData& data)
 QDataStream& operator<<(QDataStream& out, const Game::SaveUtilityInterfaceData& data)
 {
     // Writing the game list utility interface data.
+    // Series
+    long long int count = data.series.size();
+    out << count;
+    for (long long int i = 0; i < count; i++)
+        out << data.series.at(i);
+
     // Categories
-    long long int count = data.categories.size();
+    count = data.categories.size();
     out << count;
     for (long long int i = 0; i < count; i++)
         out << data.categories.at(i);
@@ -246,8 +265,17 @@ QDataStream& operator<<(QDataStream& out, const Game::SaveUtilityInterfaceData& 
 QDataStream& operator>>(QDataStream& in, Game::SaveUtilityInterfaceData& data)
 {
     // Reading the game list utility interface data from the data stream.
-    // Categories
+    // Series
     long long int count;
+    in >> count;
+    if (count > 0)
+    {
+        data.series.resize(count);
+        for (long long int i = 0; i < count; i++)
+            in >> data.series[i];
+    }
+
+    // Categories
     in >> count;
     if (count > 0)
     {
@@ -467,6 +495,7 @@ QDataStream& operator<<(QDataStream& out, const Game::ColumnsSize& data)
 {
     // Writing the size of the columns of the table view.
     out << data.name;
+    out << data.series;
     out << data.categories;
     out << data.developpers;
     out << data.publishers;
@@ -482,6 +511,7 @@ QDataStream& operator>>(QDataStream& in, Game::ColumnsSize& data)
 {
     // Reading the size of the columns of the table view.
     in >> data.name;
+    in >> data.series;
     in >> data.categories;
     in >> data.developpers;
     in >> data.publishers;

--- a/src/SqlUtilityTable.cpp
+++ b/src/SqlUtilityTable.cpp
@@ -77,6 +77,8 @@ QString SqlUtilityTable::tableName(UtilityTableName tableName)
 		return "Music";
 	case UtilityTableName::AUTHORS:
 		return "Authors";
+	case UtilityTableName::SERIES:
+		return "Series";
 	default:
 		return QString();
 	}

--- a/src/SqlUtilityTable_Game.cpp
+++ b/src/SqlUtilityTable_Game.cpp
@@ -23,6 +23,7 @@
 void SqlUtilityTable::createGameTables()
 {
 	// Creating all the Game utility table.
+	createSeriesTable();
 	createCategoriesTable();
 	createDeveloppersTable();
 	createPublishersTable();
@@ -32,6 +33,7 @@ void SqlUtilityTable::createGameTables()
 
 void SqlUtilityTable::destroyGameTables()
 {
+	destroyTableByName(tableName(UtilityTableName::SERIES));
 	destroyTableByName(tableName(UtilityTableName::CATEGORIES));
 	destroyTableByName(tableName(UtilityTableName::DEVELOPPERS));
 	destroyTableByName(tableName(UtilityTableName::PUBLISHERS));
@@ -39,6 +41,11 @@ void SqlUtilityTable::destroyGameTables()
 	destroyTableByName(tableName(UtilityTableName::SERVICES));
 	m_type = ListType::UNKNOWN;
 	m_isTableReady = false;
+}
+
+void SqlUtilityTable::createSeriesTable()
+{
+	standardTableCreation(UtilityTableName::SERIES);
 }
 
 void SqlUtilityTable::createCategoriesTable()
@@ -69,6 +76,7 @@ void SqlUtilityTable::createServicesTable()
 QVariant SqlUtilityTable::queryGameData() const
 {
 	Game::SaveUtilityData data = {};
+	data.series = retrieveTableData(UtilityTableName::SERIES);
 	data.categories = retrieveTableData(UtilityTableName::CATEGORIES);
 	data.developpers = retrieveTableData(UtilityTableName::DEVELOPPERS);
 	data.publishers = retrieveTableData(UtilityTableName::PUBLISHERS);
@@ -83,7 +91,8 @@ bool SqlUtilityTable::setGameData(const QVariant& variant)
 	// Set the data into the SQL tables.
 	Game::SaveUtilityData data = qvariant_cast<Game::SaveUtilityData>(variant);
 
-	if (!setStandardData(UtilityTableName::CATEGORIES, data.categories) ||
+	if (!setStandardData(UtilityTableName::SERIES, data.series) ||
+		!setStandardData(UtilityTableName::CATEGORIES, data.categories) ||
 		!setStandardData(UtilityTableName::DEVELOPPERS, data.developpers) ||
 		!setStandardData(UtilityTableName::PUBLISHERS, data.publishers) ||
 		!setStandardData(UtilityTableName::PLATFORM, data.platform) ||


### PR DESCRIPTION
Adding a Series column in the Games list will help people to identify from which series the game is part of.
However, this will break the compatibility with older file version which don't have the series column. The software must be able to load this older version for import.