### PR TITLE
Adding a Series column in Movies list

### DIFF
--- a/include/DataStruct.h
+++ b/include/DataStruct.h
@@ -77,6 +77,7 @@ struct MovieItem
     long long int movieID;
     long long int moviePos;
     QString name;
+    QString series;
     QString categories;
     QString directors;
     QString actors;
@@ -237,18 +238,20 @@ namespace Movie
     enum ColumnIndex
     {
         NAME = 0,
-        CATEGORIES = 1,
-        DIRECTORS = 2,
-        ACTORS = 3,
-        PRODUCTIONS = 4,
-        MUSIC = 5,
-        SERVICES = 6,
-        SENSITIVE_CONTENT = 7,
-        RATE = 8
+        SERIES = 1,
+        CATEGORIES = 2,
+        DIRECTORS = 3,
+        ACTORS = 4,
+        PRODUCTIONS = 5,
+        MUSIC = 6,
+        SERVICES = 7,
+        SENSITIVE_CONTENT = 8,
+        RATE = 9
     };
 
     struct SaveUtilityData
     {
+        QList<ItemUtilityData> series;
         QList<ItemUtilityData> categories;
         QList<ItemUtilityData> directors;
         QList<ItemUtilityData> actors;
@@ -259,6 +262,7 @@ namespace Movie
 
     struct SaveUtilityInterfaceData
     {
+        QList<Game::SaveUtilityInterfaceItem> series;
         QList<Game::SaveUtilityInterfaceItem> categories;
         QList<Game::SaveUtilityInterfaceItem> directors;
         QList<Game::SaveUtilityInterfaceItem> actors;
@@ -271,6 +275,7 @@ namespace Movie
     struct ColumnsSize
     {
         int name;
+        int series;
         int categories;
         int directors;
         int actors;

--- a/include/SaveInterface.h
+++ b/include/SaveInterface.h
@@ -38,6 +38,8 @@
 #define GLD_VERSION_MAX_SUPPORT (int)(700)
 
 #define MLD_IDENTIFIER "MLD"
+#define MLD_LEGACY_VERSION (int)(100)
+#define MLD_LEGACY_MAX_SUPPORT (int)(600)
 #define MLD_VERSION (int)(600)
 #define MLD_VERSION_MAX_SUPPORT (int) (700)
 

--- a/include/SaveInterface.h
+++ b/include/SaveInterface.h
@@ -38,8 +38,8 @@
 #define GLD_VERSION_MAX_SUPPORT (int)(700)
 
 #define MLD_IDENTIFIER "MLD"
-#define MLD_VERSION (int)(100)
-#define MLD_VERSION_MAX_SUPPORT (int) (600)
+#define MLD_VERSION (int)(600)
+#define MLD_VERSION_MAX_SUPPORT (int) (700)
 
 #define CLD_IDENTIFIER "CLD"
 #define CLD_VERSION (int)(100)

--- a/include/TableModelMovies.h
+++ b/include/TableModelMovies.h
@@ -72,6 +72,8 @@ private:
 
     void queryUtilityField(UtilityTableName tableName);
     void queryUtilityField(UtilityTableName tableName, long long int movieID);
+    void querySeriesField();
+    void querySeriesField(long long int movieID);
     void queryCategoriesField();
     void queryCategoriesField(long long int movieID);
     void queryDirectorsField();

--- a/src/FilterDialog.cpp
+++ b/src/FilterDialog.cpp
@@ -85,6 +85,7 @@ void FilterDialog::createWidget()
             {
                 "None",
                 "Name",
+                "Series",
                 "Categories",
                 "Directors",
                 "Actors",
@@ -258,23 +259,25 @@ void FilterDialog::applyFilter()
             m_model->setFilter(filter);
             accept();
         }
-        else if (m_lastIndex >= 2 && m_lastIndex <= 7)
+        else if (m_lastIndex >= 2 && m_lastIndex <= 8)
         {
             if (!m_utilityView || !m_utilityModel)
                 reject();
 
             int columnID;
             if (m_lastIndex == 2)
-                columnID = Movie::CATEGORIES;
+                columnID = Movie::SERIES;
             else if (m_lastIndex == 3)
-                columnID = Movie::DIRECTORS;
+                columnID = Movie::CATEGORIES;
             else if (m_lastIndex == 4)
-                columnID = Movie::ACTORS;
+                columnID = Movie::DIRECTORS;
             else if (m_lastIndex == 5)
-                columnID = Movie::PRODUCTIONS;
+                columnID = Movie::ACTORS;
             else if (m_lastIndex == 6)
-                columnID = Movie::MUSIC;
+                columnID = Movie::PRODUCTIONS;
             else if (m_lastIndex == 7)
+                columnID = Movie::MUSIC;
+            else if (m_lastIndex == 8)
                 columnID = Movie::SERVICES;
             
             ListFilter filter = {};
@@ -283,7 +286,7 @@ void FilterDialog::applyFilter()
             m_model->setFilter(filter);
             accept();
         }
-        else if (m_lastIndex == 8)
+        else if (m_lastIndex == 9)
         {
             ListFilter filter = {};
             filter.column = Movie::RATE;
@@ -469,20 +472,22 @@ void FilterDialog::comboBoxChanged(int index)
             m_stackedLayout->setCurrentIndex(1);
             m_nameText->clear();
         }
-        else if (index >= 2 && index <= 7)
+        else if (index >= 2 && index <= 8)
         {
             UtilityTableName tableName;
             if (index == 2)
-                tableName = UtilityTableName::CATEGORIES;
+                tableName = UtilityTableName::SERIES;
             else if (index == 3)
-                tableName = UtilityTableName::DIRECTOR;
+                tableName = UtilityTableName::CATEGORIES;
             else if (index == 4)
-                tableName = UtilityTableName::ACTORS;
+                tableName = UtilityTableName::DIRECTOR;
             else if (index == 5)
-                tableName = UtilityTableName::PRODUCTION;
+                tableName = UtilityTableName::ACTORS;
             else if (index == 6)
-                tableName = UtilityTableName::MUSIC;
+                tableName = UtilityTableName::PRODUCTION;
             else if (index == 7)
+                tableName = UtilityTableName::MUSIC;
+            else if (index == 8)
                 tableName = UtilityTableName::SERVICES;
 
             m_utilityModel = new UtilityInterfaceEditorModel(

--- a/src/ListViewDelegate.cpp
+++ b/src/ListViewDelegate.cpp
@@ -259,7 +259,7 @@ QWidget* ListViewDelegate::createEditor(QWidget* parent, const QStyleOptionViewI
 				return editor;
 			}
 		}
-		else if (index.column() >= Movie::CATEGORIES &&
+		else if (index.column() >= Movie::SERIES &&
 				 index.column() <= Movie::SERVICES)
 		{
 			long long int itemID = m_tableModel->itemID(index);
@@ -269,7 +269,9 @@ QWidget* ListViewDelegate::createEditor(QWidget* parent, const QStyleOptionViewI
 			
 			UtilityTableName tableName;
 
-			if (index.column() == Movie::CATEGORIES)
+			if (index.column() == Movie::SERIES)
+				tableName = UtilityTableName::SERIES;
+			else if (index.column() == Movie::CATEGORIES)
 				tableName = UtilityTableName::CATEGORIES;
 			else if (index.column() == Movie::DIRECTORS)
 				tableName = UtilityTableName::DIRECTOR;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -257,6 +257,11 @@ void MainWindow::createMovieToolBar()
 	connect(m_utilityMenu, &QMenu::destroyed, [this](){this->m_utilityMenu = nullptr;});
 	reinsertMenu();
 
+	QAction* serAct= new QAction(tr("Series"), m_listToolBar);
+	serAct->setToolTip(tr("Open the series editor."));
+	connect(serAct, &QAction::triggered, [this](){this->m_tabAndList->openUtility(UtilityTableName::SERIES);});
+	m_utilityMenu->addAction(serAct);
+
 	QAction* catAct = new QAction(tr("Categories"), m_listToolBar);
 	catAct->setToolTip(tr("Open the categories editor."));
 	connect(catAct, &QAction::triggered, [this](){this->m_tabAndList->openUtility(UtilityTableName::CATEGORIES);});

--- a/src/MoviesListView.cpp
+++ b/src/MoviesListView.cpp
@@ -227,6 +227,7 @@ QVariant MoviesListView::listData() const
             // Retrieve the size of the column.
             Movie::SaveDataTable data = qvariant_cast<Movie::SaveDataTable>(variant);
             data.viewColumnsSize.name = m_view->columnWidth(Movie::NAME);
+            data.viewColumnsSize.series = m_view->columnWidth(Movie::SERIES);
             data.viewColumnsSize.categories = m_view->columnWidth(Movie::CATEGORIES);
             data.viewColumnsSize.directors = m_view->columnWidth(Movie::DIRECTORS);
             data.viewColumnsSize.actors = m_view->columnWidth(Movie::ACTORS);
@@ -259,6 +260,7 @@ void MoviesListView::setColumnsSizeAndSortingOrder(const QVariant& variant)
         {
             Movie::SaveDataTable data = qvariant_cast<Movie::SaveDataTable>(variant);
             m_view->setColumnWidth(Movie::NAME, data.viewColumnsSize.name);
+            m_view->setColumnWidth(Movie::SERIES, data.viewColumnsSize.series);
             m_view->setColumnWidth(Movie::CATEGORIES, data.viewColumnsSize.categories);
             m_view->setColumnWidth(Movie::DIRECTORS, data.viewColumnsSize.directors);
             m_view->setColumnWidth(Movie::ACTORS, data.viewColumnsSize.actors);

--- a/src/SaveInterface_Movies.cpp
+++ b/src/SaveInterface_Movies.cpp
@@ -85,6 +85,12 @@ bool SaveInterface::openMovies(QDataStream* in, QVariant& variant)
     {
         if (in->atEnd())
             return false;
+
+        // Check if it's a legacy MLD file.
+        if (fileVersion >= MLD_LEGACY_VERSION && fileVersion < MLD_LEGACY_MAX_SUPPORT)
+            m_isLegacy = true;
+        else
+            m_isLegacy = false;
         
         // Data.
         Movie::SaveData data = {};
@@ -151,12 +157,15 @@ QDataStream& operator>>(QDataStream& in, Movie::SaveUtilityData& data)
 {
     // Reading the SQL Utility data from the data stream.
     long long int count;
-    in >> count;
-    if (count > 0)
+    if (!SaveInterface::isLegacy())
     {
-        data.series.resize(count);
-        for (long long int i = 0; i < count; i++)
-            in >> data.series[i];
+        in >> count;
+        if (count > 0)
+        {
+            data.series.resize(count);
+            for (long long int i = 0; i < count; i++)
+                in >> data.series[i];
+        }
     }
 
     in >> count;
@@ -260,12 +269,15 @@ QDataStream& operator>>(QDataStream& in, Movie::SaveUtilityInterfaceData& data)
 {
     // Reading the movies list utility interface data.
     long long int count;
-    in >> count;
-    if (count > 0)
+    if (!SaveInterface::isLegacy())
     {
-        data.series.resize(count);
-        for (long long int i = 0; i < count; i++)
-            in >> data.series[i];
+        in >> count;
+        if (count > 0)
+        {
+            data.series.resize(count);
+            for (long long int i = 0; i < count; i++)
+                in >> data.series[i];
+        }
     }
 
     in >> count;
@@ -439,7 +451,10 @@ QDataStream& operator>>(QDataStream& in, Movie::ColumnsSize& data)
 {
     // Reading the size of the columns of the table view.
     in >> data.name;
-    in >> data.series;
+    if (!SaveInterface::isLegacy())
+        in >> data.series;
+    else
+        data.series = 140;
     in >> data.categories;
     in >> data.directors;
     in >> data.actors;

--- a/src/SaveInterface_Movies.cpp
+++ b/src/SaveInterface_Movies.cpp
@@ -81,7 +81,7 @@ bool SaveInterface::openMovies(QDataStream* in, QVariant& variant)
     // Version
     int fileVersion;
     *in >> fileVersion;
-    if (fileVersion >= MLD_VERSION && fileVersion < MLD_VERSION_MAX_SUPPORT)
+    if (fileVersion >= MLD_LEGACY_VERSION && fileVersion < MLD_VERSION_MAX_SUPPORT)
     {
         if (in->atEnd())
             return false;

--- a/src/SaveInterface_Movies.cpp
+++ b/src/SaveInterface_Movies.cpp
@@ -109,7 +109,12 @@ bool SaveInterface::openMovies(QDataStream* in, QVariant& variant)
 QDataStream& operator<<(QDataStream& out, const Movie::SaveUtilityData& data)
 {
     // Writing the SQL Utility data to the data stream.
-    long long int count = data.categories.size();
+    long long int count = data.series.size();
+    out << count;
+    for (long long int i = 0; i < count; i++)
+        out << data.series.at(i);
+
+    count = data.categories.size();
     out << count;
     for (long long int i = 0; i < count; i++)
         out << data.categories.at(i);
@@ -146,6 +151,14 @@ QDataStream& operator>>(QDataStream& in, Movie::SaveUtilityData& data)
 {
     // Reading the SQL Utility data from the data stream.
     long long int count;
+    in >> count;
+    if (count > 0)
+    {
+        data.series.resize(count);
+        for (long long int i = 0; i < count; i++)
+            in >> data.series[i];
+    }
+
     in >> count;
     if (count > 0)
     {
@@ -200,7 +213,12 @@ QDataStream& operator>>(QDataStream& in, Movie::SaveUtilityData& data)
 QDataStream& operator<<(QDataStream& out, const Movie::SaveUtilityInterfaceData& data)
 {
     // Writing the movies list utility interface data.
-    long long int count = data.categories.size();
+    long long int count = data.series.size();
+    out << count;
+    for (long long int i = 0; i < count; i++)
+        out << data.series.at(i);
+
+    count = data.categories.size();
     out << count;
     for (long long int i = 0; i < count; i++)
         out << data.categories.at(i);
@@ -242,6 +260,14 @@ QDataStream& operator>>(QDataStream& in, Movie::SaveUtilityInterfaceData& data)
 {
     // Reading the movies list utility interface data.
     long long int count;
+    in >> count;
+    if (count > 0)
+    {
+        data.series.resize(count);
+        for (long long int i = 0; i < count; i++)
+            in >> data.series[i];
+    }
+
     in >> count;
     if (count > 0)
     {
@@ -397,6 +423,7 @@ QDataStream& operator<<(QDataStream& out, const Movie::ColumnsSize& data)
 {
     // Writing the size of the columns of the table view.
     out << data.name;
+    out << data.series;
     out << data.categories;
     out << data.directors;
     out << data.actors;
@@ -412,6 +439,7 @@ QDataStream& operator>>(QDataStream& in, Movie::ColumnsSize& data)
 {
     // Reading the size of the columns of the table view.
     in >> data.name;
+    in >> data.series;
     in >> data.categories;
     in >> data.directors;
     in >> data.actors;

--- a/src/SqlUtilityTable_Movies.cpp
+++ b/src/SqlUtilityTable_Movies.cpp
@@ -23,6 +23,7 @@
 void SqlUtilityTable::createMoviesTables()
 {
     // Creating all the Movies utility table.
+    createSeriesTable();
     createCategoriesTable();
     createDirectoryTable();
     createActorsTable();
@@ -33,6 +34,7 @@ void SqlUtilityTable::createMoviesTables()
 
 void SqlUtilityTable::destroyMoviesTables()
 {
+    destroyTableByName(tableName(UtilityTableName::SERIES));
     destroyTableByName(tableName(UtilityTableName::CATEGORIES));
     destroyTableByName(tableName(UtilityTableName::DIRECTOR));
     destroyTableByName(tableName(UtilityTableName::ACTORS));
@@ -64,6 +66,7 @@ void SqlUtilityTable::createMusicTable()
 QVariant SqlUtilityTable::queryMoviesData() const
 {
     Movie::SaveUtilityData data = {};
+    data.series = retrieveTableData(UtilityTableName::SERIES);
     data.categories = retrieveTableData(UtilityTableName::CATEGORIES);
     data.directors = retrieveTableData(UtilityTableName::DIRECTOR);
     data.actors = retrieveTableData(UtilityTableName::ACTORS);
@@ -78,7 +81,8 @@ bool SqlUtilityTable::setMoviesData(const QVariant& variant)
 {
     Movie::SaveUtilityData data = qvariant_cast<Movie::SaveUtilityData>(variant);
 
-    if (!setStandardData(UtilityTableName::CATEGORIES, data.categories) ||
+    if (!setStandardData(UtilityTableName::SERIES, data.series) ||
+        !setStandardData(UtilityTableName::CATEGORIES, data.categories) ||
         !setStandardData(UtilityTableName::DIRECTOR, data.directors) ||
         !setStandardData(UtilityTableName::ACTORS, data.actors) ||
         !setStandardData(UtilityTableName::PRODUCTION, data.productions) ||

--- a/src/TableModelMovies_UtilityInterface.cpp
+++ b/src/TableModelMovies_UtilityInterface.cpp
@@ -42,6 +42,8 @@ QString TableModelMovies_UtilityInterface::tableName(UtilityTableName tableName)
     // Return the table name of a specific utility
     switch (tableName)
     {
+    case UtilityTableName::SERIES:
+        return m_parentTableName + "_Series";
     case UtilityTableName::CATEGORIES:
         return m_parentTableName + "_Categories";
     case UtilityTableName::DIRECTOR:
@@ -68,33 +70,36 @@ void TableModelMovies_UtilityInterface::newParentName(const QString& newParentNa
         return;
     
     // Storing the current table name into variable.
+    QString serCurName = tableName(UtilityTableName::SERIES);
     QString catCurName = tableName(UtilityTableName::CATEGORIES);
     QString dirCurName = tableName(UtilityTableName::DIRECTOR);
     QString actCurName = tableName(UtilityTableName::ACTORS);
     QString proCurName = tableName(UtilityTableName::PRODUCTION);
     QString musCurName = tableName(UtilityTableName::MUSIC);
-    QString serCurName = tableName(UtilityTableName::SERVICES);
+    QString servCurName = tableName(UtilityTableName::SERVICES);
     QString sensCurName = tableName(UtilityTableName::SENSITIVE_CONTENT);
 
     // Changing the parent table name to the new parent name.
     m_parentTableName = newParentName;
 
     // Get the new table name.
+    QString serNewName = tableName(UtilityTableName::SERIES);
     QString catNewName = tableName(UtilityTableName::CATEGORIES);
     QString dirNewName = tableName(UtilityTableName::DIRECTOR);
     QString actNewName = tableName(UtilityTableName::ACTORS);
     QString proNewName = tableName(UtilityTableName::PRODUCTION);
     QString musNewName = tableName(UtilityTableName::MUSIC);
-    QString serNewName = tableName(UtilityTableName::SERVICES);
+    QString servNewName = tableName(UtilityTableName::SERVICES);
     QString sensNewName = tableName(UtilityTableName::SENSITIVE_CONTENT);
 
     // Renaming the tables
+    renameTable(serCurName, serNewName);
     renameTable(catCurName, catNewName);
     renameTable(dirCurName, dirNewName);
     renameTable(actCurName, actNewName);
     renameTable(proCurName, proNewName);
     renameTable(musCurName, musNewName);
-    renameTable(serCurName, serNewName);
+    renameTable(servCurName, servNewName);
     renameTable(sensCurName, sensNewName);
 }
 
@@ -112,8 +117,9 @@ void TableModelMovies_UtilityInterface::rowRemoved(const QList<long long int>& m
         idList += QString::number(moviesID.at(i));
     }
 
-    UtilityTableName tablesName[7] =
+    UtilityTableName tablesName[9] =
     {
+        UtilityTableName::SERIES,
         UtilityTableName::CATEGORIES,
         UtilityTableName::DIRECTOR,
         UtilityTableName::ACTORS,
@@ -123,7 +129,7 @@ void TableModelMovies_UtilityInterface::rowRemoved(const QList<long long int>& m
         UtilityTableName::SENSITIVE_CONTENT
     };
 
-    for (int i = 0; i < 7; i++)
+    for (int i = 0; i < 8; i++)
     {
         QString statement = QString(
             "DELETE FROM \"%1\"\n"
@@ -266,8 +272,9 @@ QVariant TableModelMovies_UtilityInterface::data() const
         "ORDER BY\n"
         "   ItemID;");
     
-    UtilityTableName tablesName[6] =
+    UtilityTableName tablesName[7] =
     {
+        UtilityTableName::SERIES,
         UtilityTableName::CATEGORIES,
         UtilityTableName::DIRECTOR,
         UtilityTableName::ACTORS,
@@ -277,7 +284,7 @@ QVariant TableModelMovies_UtilityInterface::data() const
     };
 
     // Utility interface (Categories, Director, Actors, Production, Music, Services).
-    for (int i = 0; i < 6; i++)
+    for (int i = 0; i < 7; i++)
     {
 #ifndef NDEBUG
         std::cout << statement.arg(tableName(tablesName[i])).toLocal8Bit().constData() << std::endl << std::endl;
@@ -297,7 +304,9 @@ QVariant TableModelMovies_UtilityInterface::data() const
             Game::SaveUtilityInterfaceItem item = {};
             item.gameID = query.value(0).toLongLong();
             item.utilityID = query.value(1).toLongLong();
-            if (tablesName[i] == UtilityTableName::CATEGORIES)
+            if (tablesName[i] == UtilityTableName::SERIES)
+                data.series.append(item);
+            else if (tablesName[i] == UtilityTableName::CATEGORIES)
                 data.categories.append(item);
             else if (tablesName[i] == UtilityTableName::DIRECTOR)
                 data.directors.append(item);
@@ -362,8 +371,9 @@ bool TableModelMovies_UtilityInterface::setData(const QVariant& variant)
     
     Movie::SaveUtilityInterfaceData data = qvariant_cast<Movie::SaveUtilityInterfaceData>(variant);
 
-    UtilityTableName tablesName[6] =
+    UtilityTableName tablesName[7] =
     {
+        UtilityTableName::SERIES,
         UtilityTableName::CATEGORIES,
         UtilityTableName::DIRECTOR,
         UtilityTableName::ACTORS,
@@ -377,10 +387,12 @@ bool TableModelMovies_UtilityInterface::setData(const QVariant& variant)
         "INSERT INTO \"%1\" (ItemID, UtilityID)\n"
         "VALUES");
     
-    for (int i = 0; i < 6; i++)
+    for (int i = 0; i < 7; i++)
     {
         QList<Game::SaveUtilityInterfaceItem>* pItem;
-        if (tablesName[i] == UtilityTableName::CATEGORIES)
+        if (tablesName[i] == UtilityTableName::SERIES)
+            pItem = &data.series;
+        else if (tablesName[i] == UtilityTableName::CATEGORIES)
             pItem = &data.categories;
         else if (tablesName[i] == UtilityTableName::DIRECTOR)
             pItem = &data.directors;
@@ -479,8 +491,9 @@ void TableModelMovies_UtilityInterface::createTables()
         "   ItemID INTEGER,\n"
         "   UtilityID INTEGER);");
 
-    UtilityTableName tablesName[6] =
+    UtilityTableName tablesName[7] =
     {
+        UtilityTableName::SERIES,
         UtilityTableName::CATEGORIES,
         UtilityTableName::DIRECTOR,
         UtilityTableName::ACTORS,
@@ -489,7 +502,7 @@ void TableModelMovies_UtilityInterface::createTables()
         UtilityTableName::SERVICES
     };
 
-    for (int i = 0; i < 6; i++)
+    for (int i = 0; i < 7; i++)
     {
 #ifndef NDEBUG
         std::cout << statement.arg(tableName(tablesName[i])).toLocal8Bit().constData() << std::endl << std::endl;
@@ -539,6 +552,7 @@ void TableModelMovies_UtilityInterface::createTables()
 
 void TableModelMovies_UtilityInterface::destroyTables()
 {
+    destroyTableByName(tableName(UtilityTableName::SERIES));
     destroyTableByName(tableName(UtilityTableName::CATEGORIES));
     destroyTableByName(tableName(UtilityTableName::DIRECTOR));
     destroyTableByName(tableName(UtilityTableName::ACTORS));


### PR DESCRIPTION
Adding a Series column in the Movies list will help people to identify from which series the movie is part of.
However, this will break the compatibility with older file version which don't have the series column. The software must be able to load the older version for import.