### PR TITLE
Common series column

### DIFF
--- a/include/DataStruct.h
+++ b/include/DataStruct.h
@@ -94,6 +94,7 @@ struct CommonItem
     long long int commonID;
     long long int commonPos;
     QString name;
+    QString series;
     QString categories;
     QString authors;
     SensitiveContent sensitiveContent;
@@ -321,20 +322,23 @@ namespace Common
     enum ColumnIndex
     {
         NAME = 0,
-        CATEGORIES = 1,
-        AUTHORS = 2,
-        SENSITIVE_CONTENT = 3,
-        RATE = 4
+        SERIES = 1,
+        CATEGORIES = 2,
+        AUTHORS = 3,
+        SENSITIVE_CONTENT = 4,
+        RATE = 5
     };
 
     struct SaveUtilityData
     {
+        QList<ItemUtilityData> series;
         QList<ItemUtilityData> categories;
         QList<ItemUtilityData> authors;
     };
 
     struct SaveUtilityInterfaceData
     {
+        QList<Game::SaveUtilityInterfaceItem> series;
         QList<Game::SaveUtilityInterfaceItem> categories;
         QList<Game::SaveUtilityInterfaceItem> authors;
         QList<Game::SaveUtilitySensitiveContentItem> sensitiveContent;
@@ -343,6 +347,7 @@ namespace Common
     struct ColumnsSize
     {
         int name;
+        int series;
         int categories;
         int authors;
         int sensitiveContent;

--- a/include/SaveInterface.h
+++ b/include/SaveInterface.h
@@ -44,8 +44,8 @@
 #define MLD_VERSION_MAX_SUPPORT (int) (700)
 
 #define CLD_IDENTIFIER "CLD"
-#define CLD_VERSION (int)(100)
-#define CLD_VERSION_MAX_SUPPORT (int)(200)
+#define CLD_VERSION (int)(200)
+#define CLD_VERSION_MAX_SUPPORT (int)(300)
 
 #define BLD_IDENTIFIER "BLD"
 #define BLD_VERSION (int)(100)

--- a/include/TableModelCommon.h
+++ b/include/TableModelCommon.h
@@ -72,6 +72,8 @@ private:
 
     void queryUtilityField(UtilityTableName tableName);
     void queryUtilityField(UtilityTableName tableName, long long int commonID);
+    void querySeriesField();
+    void querySeriesField(long long int commonID);
     void queryCategoriesField();
     void queryCategoriesField(long long int commonID);
     void queryAuthorsField();

--- a/src/CommonListView.cpp
+++ b/src/CommonListView.cpp
@@ -226,6 +226,7 @@ QVariant CommonListView::listData() const
             // Retrieve the size of the column.
             Common::SaveDataTable data = qvariant_cast<Common::SaveDataTable>(variant);
             data.viewColumnsSize.name = m_view->columnWidth(Common::NAME);
+            data.viewColumnsSize.series = m_view->columnWidth(Common::SERIES);
             data.viewColumnsSize.categories = m_view->columnWidth(Common::CATEGORIES);
             data.viewColumnsSize.authors = m_view->columnWidth(Common::AUTHORS);
             data.viewColumnsSize.sensitiveContent = m_view->columnWidth(Common::SENSITIVE_CONTENT);
@@ -252,6 +253,7 @@ void CommonListView::setColumnsSizeAndSortingOrder(const QVariant& variant)
     {
         Common::SaveDataTable data = qvariant_cast<Common::SaveDataTable>(variant);
         m_view->setColumnWidth(Common::NAME, data.viewColumnsSize.name);
+        m_view->setColumnWidth(Common::SERIES, data.viewColumnsSize.series);
         m_view->setColumnWidth(Common::CATEGORIES, data.viewColumnsSize.categories);
         m_view->setColumnWidth(Common::AUTHORS, data.viewColumnsSize.authors);
         m_view->setColumnWidth(Common::SENSITIVE_CONTENT, data.viewColumnsSize.sensitiveContent);

--- a/src/FilterDialog.cpp
+++ b/src/FilterDialog.cpp
@@ -100,6 +100,7 @@ void FilterDialog::createWidget()
         comboBox->addItems(
             {
                 "None",
+                "Series",
                 "Name",
                 "Categories",
                 "Authors",
@@ -312,15 +313,17 @@ void FilterDialog::applyFilter()
             m_model->setFilter(filter);
             accept();
         }
-        else if (m_lastIndex >= 2 && m_lastIndex <= 3)
+        else if (m_lastIndex >= 2 && m_lastIndex <= 4)
         {
             if (!m_utilityView || m_lastIndex <= 7)
                 reject();
             
             int columnID;
             if (m_lastIndex == 2)
-                columnID = Common::CATEGORIES;
+                columnID = Common::SERIES;
             else if (m_lastIndex == 3)
+                columnID = Common::CATEGORIES;
+            else if (m_lastIndex == 4)
                 columnID = Common::AUTHORS;
             
             ListFilter filter = {};
@@ -329,7 +332,7 @@ void FilterDialog::applyFilter()
             m_model->setFilter(filter);
             accept();
         }
-        else if (m_lastIndex == 4)
+        else if (m_lastIndex == 5)
         {
             ListFilter filter = {};
             filter.column = Common::RATE;
@@ -524,12 +527,14 @@ void FilterDialog::comboBoxChanged(int index)
             m_stackedLayout->setCurrentIndex(1);
             m_nameText->clear();
         }
-        else if (index >= 2 && index <= 3)
+        else if (index >= 2 && index <= 4)
         {
             UtilityTableName tableName;
             if (index == 2)
-                tableName = UtilityTableName::CATEGORIES;
+                tableName == UtilityTableName::SERIES;
             else if (index == 3)
+                tableName = UtilityTableName::CATEGORIES;
+            else if (index == 4)
                 tableName = UtilityTableName::AUTHORS;
             
             m_utilityModel = new UtilityInterfaceEditorModel(

--- a/src/FilterDialog.cpp
+++ b/src/FilterDialog.cpp
@@ -100,8 +100,8 @@ void FilterDialog::createWidget()
         comboBox->addItems(
             {
                 "None",
-                "Series",
                 "Name",
+                "Series",
                 "Categories",
                 "Authors",
                 "Rate"

--- a/src/FilterDialog.cpp
+++ b/src/FilterDialog.cpp
@@ -531,7 +531,7 @@ void FilterDialog::comboBoxChanged(int index)
         {
             UtilityTableName tableName;
             if (index == 2)
-                tableName == UtilityTableName::SERIES;
+                tableName = UtilityTableName::SERIES;
             else if (index == 3)
                 tableName = UtilityTableName::CATEGORIES;
             else if (index == 4)

--- a/src/ListViewDelegate.cpp
+++ b/src/ListViewDelegate.cpp
@@ -335,7 +335,8 @@ QWidget* ListViewDelegate::createEditor(QWidget* parent, const QStyleOptionViewI
 				return editor;
 			}
 		}
-		else if (index.column() == Common::CATEGORIES ||
+		else if (index.column() == Common::SERIES ||
+				 index.column() == Common::CATEGORIES ||
 				 index.column() == Common::AUTHORS)
 		{
 			long long int itemID = m_tableModel->itemID(index);
@@ -345,7 +346,9 @@ QWidget* ListViewDelegate::createEditor(QWidget* parent, const QStyleOptionViewI
 			
 			UtilityTableName tableName;
 
-			if (index.column() == Common::CATEGORIES)
+			if (index.column() == Common::SERIES)
+				tableName = UtilityTableName::SERIES;
+			else if (index.column() == Common::CATEGORIES)
 				tableName = UtilityTableName::CATEGORIES;
 			else if (index.column() == Common::AUTHORS)
 				tableName = UtilityTableName::AUTHORS;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -313,6 +313,11 @@ void MainWindow::createCommonToolBar()
 	connect(m_utilityMenu, &QMenu::destroyed, [this](){this->m_utilityMenu = nullptr;});
 	reinsertMenu();
 
+	QAction* serAct= new QAction(tr("Series"), m_listToolBar);
+	serAct->setToolTip(tr("Open the series editor."));
+	connect(serAct, &QAction::triggered, [this](){this->m_tabAndList->openUtility(UtilityTableName::SERIES);});
+	m_utilityMenu->addAction(serAct);
+
 	QAction* catAct = new QAction(tr("Categories"), m_listToolBar);
 	catAct->setToolTip(tr("Open the categories editor."));
 	connect(catAct, &QAction::triggered, [this](){this->m_tabAndList->openUtility(UtilityTableName::CATEGORIES);});

--- a/src/SaveInterface_Common.cpp
+++ b/src/SaveInterface_Common.cpp
@@ -109,7 +109,12 @@ bool SaveInterface::openCommonList(QDataStream* in, QVariant& variant)
 QDataStream& operator<<(QDataStream& out, const Common::SaveUtilityData& data)
 {
     // Writing the SQL Utility data to the data stream.
-    long long int count = data.categories.size();
+    long long int count = data.series.size();
+    out << count;
+    for (long long int i = 0; i < count; i++)
+        out << data.series.at(i);
+
+    count = data.categories.size();
     out << count;
     for (long long int i = 0; i < count; i++)
         out << data.categories.at(i);
@@ -126,6 +131,14 @@ QDataStream& operator>>(QDataStream& in, Common::SaveUtilityData& data)
 {
     // Reading the SQL Utility data from the data stream.
     long long int count;
+    in >> count;
+    if (count > 0)
+    {
+        data.series.resize(count);
+        for (long long int i = 0; i < count; i++)
+            in >> data.series[i];
+    }
+
     in >> count;
     if (count > 0)
     {
@@ -148,7 +161,12 @@ QDataStream& operator>>(QDataStream& in, Common::SaveUtilityData& data)
 QDataStream& operator<<(QDataStream& out, const Common::SaveUtilityInterfaceData& data)
 {
     // Wrinting the commons list utility interface data.
-    long long int count = data.categories.size();
+    long long int count = data.series.size();
+    out << count;
+    for (long long int i = 0; i < count; i++)
+        out << data.series.at(i);
+
+    count = data.categories.size();
     out << count;
     for (long long int i = 0; i < count; i++)
         out << data.categories.at(i);
@@ -170,6 +188,14 @@ QDataStream& operator>>(QDataStream& in, Common::SaveUtilityInterfaceData& data)
 {
     // Reading the commons list utility interface data.
     long long int count;
+    in >> count;
+    if (count > 0)
+    {
+        data.series.resize(count);
+        for (long long int i = 0; i < count; i++)
+            in >> data.series[i];
+    }
+
     in >> count;
     if (count > 0)
     {
@@ -292,6 +318,7 @@ QDataStream& operator<<(QDataStream& out, const Common::ColumnsSize& data)
 {
     // Writing the size of the columns of the table view.
     out << data.name;
+    out << data.series;
     out << data.categories;
     out << data.authors;
     out << data.sensitiveContent;
@@ -303,6 +330,7 @@ QDataStream& operator>>(QDataStream&  in, Common::ColumnsSize& data)
 {
     // Reading the size of the columns of the table view.
     in >> data.name;
+    in >> data.series;
     in >> data.categories;
     in >> data.authors;
     in >> data.sensitiveContent;

--- a/src/SqlUtilityTable_Common.cpp
+++ b/src/SqlUtilityTable_Common.cpp
@@ -23,12 +23,14 @@
 void SqlUtilityTable::createCommonTables()
 {
     // Creating all the Common utility table.
+    createSeriesTable();
     createCategoriesTable();
     createAuthorsTables();
 }
 
 void SqlUtilityTable::destroyCommonTables()
 {
+    destroyTableByName(tableName(UtilityTableName::SERIES));
     destroyTableByName(tableName(UtilityTableName::CATEGORIES));
     destroyTableByName(tableName(UtilityTableName::AUTHORS));
 }
@@ -41,6 +43,7 @@ void SqlUtilityTable::createAuthorsTables()
 QVariant SqlUtilityTable::queryCommonsData() const
 {
     Common::SaveUtilityData data = {};
+    data.series = retrieveTableData(UtilityTableName::SERIES);
     data.categories = retrieveTableData(UtilityTableName::CATEGORIES);
     data.authors = retrieveTableData(UtilityTableName::AUTHORS);
     return QVariant::fromValue(data);
@@ -50,7 +53,8 @@ bool SqlUtilityTable::setCommonsData(const QVariant& variant)
 {
     Common::SaveUtilityData data = qvariant_cast<Common::SaveUtilityData>(variant);
 
-    if (!setStandardData(UtilityTableName::CATEGORIES, data.categories) ||
+    if (!setStandardData(UtilityTableName::SERIES, data.series) ||
+        !setStandardData(UtilityTableName::CATEGORIES, data.categories) ||
         !setStandardData(UtilityTableName::AUTHORS, data.authors))
         return false;
     


### PR DESCRIPTION
Adding a Series column in the Common list will help people to identify from which series the item is part of.
There is no need to retro compatibility since no stable version ever came out with the common list.