### PR TITLE
Add edit menu

### DIFF
--- a/include/BooksListView.h
+++ b/include/BooksListView.h
@@ -50,6 +50,8 @@ signals:
 public slots:
     void addingItem();
     void deletingItems();
+    void copy();
+    void paste();
 
 private slots:
     void setUrl();
@@ -58,8 +60,6 @@ private slots:
     void moveItemDown();
     void moveItemTo();
     void filter();
-    void copy();
-    void paste();
 
 private:
     void setupWidget();

--- a/include/CommonListView.h
+++ b/include/CommonListView.h
@@ -50,6 +50,8 @@ signals:
 public slots:
     void addingItem();
     void deletingItems();
+    void copy();
+    void paste();
 
 private slots:
     void setUrl();
@@ -58,8 +60,6 @@ private slots:
     void moveItemDown();
     void moveItemTo();
     void filter();
-    void copy();
-    void paste();
 
 private:
     void setupWidget();

--- a/include/GameListView.h
+++ b/include/GameListView.h
@@ -50,6 +50,8 @@ signals:
 public slots:
     void addingItem();
     void deletingItems();
+    void copy();
+    void paste();
     
 private slots:
     void setUrl();
@@ -58,8 +60,6 @@ private slots:
     void moveItemDown();
     void moveItemTo();
     void filter();
-    void copy();
-    void paste();
 
 private:
     void setupWidget();

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -72,6 +72,7 @@ private:
 	bool m_doNotSaveSettings;
 
 	QMenu* m_fileMenu;
+	QMenu* m_editMenu;
 	QMenu* m_utilityMenu;
 	QMenu* m_helpMenu;
 	QMenu* m_recentFileMenu;

--- a/include/MoviesListView.h
+++ b/include/MoviesListView.h
@@ -50,6 +50,8 @@ signals:
 public slots:
     void addingItem();
     void deletingItems();
+    void copy();
+    void paste();
 
 private slots:
     void setUrl();
@@ -58,8 +60,6 @@ private slots:
     void moveItemDown();
     void moveItemTo();
     void filter();
-    void copy();
-    void paste();
 
 private:
     void setupWidget();

--- a/include/SeriesListView.h
+++ b/include/SeriesListView.h
@@ -50,6 +50,8 @@ signals:
 public slots:
     void addingItem();
     void deletingItems();
+    void copy();
+    void paste();
 
 private slots:
     void setUrl();
@@ -58,8 +60,6 @@ private slots:
     void moveItemDown();
     void moveItemTo();
     void filter();
-    void copy();
-    void paste();
 
 private:
     void setupWidget();

--- a/include/TabAndList.h
+++ b/include/TabAndList.h
@@ -62,6 +62,8 @@ signals:
     void newList(ListType listType);
     void newListFileName(const QString& filePath);
     void listChanged(bool isChanged);
+    void isAddDelEditVisible(bool value);
+    void isCopyPasteEditVisible(bool value);
 
 private slots:
     void tabChanged(int index);

--- a/include/TabAndList.h
+++ b/include/TabAndList.h
@@ -53,6 +53,10 @@ public slots:
     void save();
     void saveAs();
     void openUtility(UtilityTableName tableName);
+    void addItem();
+    void delItem();
+    void copyItem();
+    void pasteItem();
 
 signals:
     void newList(ListType listType);

--- a/include/UtilityListView.h
+++ b/include/UtilityListView.h
@@ -38,16 +38,18 @@ public:
     virtual ViewType viewType() const override;
     UtilityTableName tableName() const;
 
+public slots:
+    void addItem();
+    void deleteSelectedRows();
+
 private slots:
     void moveItemUp();
     void moveItemDown();
     void moveItemTo();
-    void addItem();
 
 private:
     void createMenu();
     void createView();
-    void deleteSelectedRows();
 
     UtilityTableName m_uName;
     QTableView* m_view;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -180,25 +180,33 @@ void MainWindow::createMenu()
 	QIcon addItemIcon(":/Images/Add.svg");
 	QAction* addItemAct = new QAction(addItemIcon, tr("Add item"), this);
 	addItemAct->setToolTip(tr("Add an item into the current view."));
+	addItemAct->setEnabled(false);
 	connect(addItemAct, &QAction::triggered, m_tabAndList, &TabAndList::addItem);
+	connect(m_tabAndList, &TabAndList::isAddDelEditVisible, addItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(addItemAct);
 
 	QIcon delItemIcon(":/Images/Del.svg");
 	QAction* delItemAct = new QAction(delItemIcon, tr("Delete item"), this);
 	delItemAct->setToolTip(tr("Delete an item from the current view."));
+	delItemAct->setEnabled(false);
 	connect(delItemAct, &QAction::triggered, m_tabAndList, &TabAndList::delItem);
+	connect(m_tabAndList, &TabAndList::isAddDelEditVisible, delItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(delItemAct);
 
 	QIcon copyItemIcon(":/Images/Copy.svg");
 	QAction* copyItemAct = new QAction(copyItemIcon, tr("Copy item"), this);
 	copyItemAct->setToolTip(tr("Copy the selected items from the current view."));
+	copyItemAct->setEnabled(false);
 	connect(copyItemAct, &QAction::triggered, m_tabAndList, &TabAndList::copyItem);
+	connect(m_tabAndList, &TabAndList::isCopyPasteEditVisible, copyItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(copyItemAct);
 
 	QIcon pasteItemIcon(":/Images/Paste.svg");
 	QAction* pasteItemAct = new QAction(pasteItemIcon, tr("Paste item"), this);
 	pasteItemAct->setToolTip(tr("Paste item from the clipboard into the current view."));
+	pasteItemAct->setEnabled(false);
 	connect(pasteItemAct, &QAction::triggered, m_tabAndList, &TabAndList::pasteItem);
+	connect(m_tabAndList, &TabAndList::isCopyPasteEditVisible, pasteItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(pasteItemAct);
 
 	// Add help menu

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -181,6 +181,7 @@ void MainWindow::createMenu()
 	QAction* addItemAct = new QAction(addItemIcon, tr("Add item"), this);
 	addItemAct->setToolTip(tr("Add an item into the current view."));
 	addItemAct->setEnabled(false);
+	addItemAct->setShortcut(Qt::CTRL | Qt::Key_A);
 	connect(addItemAct, &QAction::triggered, m_tabAndList, &TabAndList::addItem);
 	connect(m_tabAndList, &TabAndList::isAddDelEditVisible, addItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(addItemAct);
@@ -189,6 +190,7 @@ void MainWindow::createMenu()
 	QAction* delItemAct = new QAction(delItemIcon, tr("Delete item"), this);
 	delItemAct->setToolTip(tr("Delete an item from the current view."));
 	delItemAct->setEnabled(false);
+	delItemAct->setShortcut(Qt::CTRL | Qt::Key_D);
 	connect(delItemAct, &QAction::triggered, m_tabAndList, &TabAndList::delItem);
 	connect(m_tabAndList, &TabAndList::isAddDelEditVisible, delItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(delItemAct);
@@ -197,6 +199,7 @@ void MainWindow::createMenu()
 	QAction* copyItemAct = new QAction(copyItemIcon, tr("Copy item"), this);
 	copyItemAct->setToolTip(tr("Copy the selected items from the current view."));
 	copyItemAct->setEnabled(false);
+	copyItemAct->setShortcut(QKeySequence::Copy);
 	connect(copyItemAct, &QAction::triggered, m_tabAndList, &TabAndList::copyItem);
 	connect(m_tabAndList, &TabAndList::isCopyPasteEditVisible, copyItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(copyItemAct);
@@ -205,6 +208,7 @@ void MainWindow::createMenu()
 	QAction* pasteItemAct = new QAction(pasteItemIcon, tr("Paste item"), this);
 	pasteItemAct->setToolTip(tr("Paste item from the clipboard into the current view."));
 	pasteItemAct->setEnabled(false);
+	pasteItemAct->setShortcut(QKeySequence::Paste);
 	connect(pasteItemAct, &QAction::triggered, m_tabAndList, &TabAndList::pasteItem);
 	connect(m_tabAndList, &TabAndList::isCopyPasteEditVisible, pasteItemAct, &QAction::setEnabled);
 	m_editMenu->addAction(pasteItemAct);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -50,6 +50,7 @@ MainWindow::MainWindow(const QString& filePath, bool resetSettings, bool doNotSa
 	m_doNotSaveSettings(doNotSaveSettings),
 
 	m_fileMenu(nullptr),
+	m_editMenu(nullptr),
 	m_utilityMenu(nullptr),
 	m_helpMenu(nullptr),
 	m_recentFileMenu(nullptr),
@@ -173,6 +174,28 @@ void MainWindow::createMenu()
 #endif
 	connect(quitAct, &QAction::triggered, this, &MainWindow::close);
 	m_fileMenu->addAction(quitAct);
+
+	// Edit menu
+	m_editMenu = menuBar()->addMenu(tr("Edit"));
+	QIcon addItemIcon(":/Images/Add.svg");
+	QAction* addItemAct = new QAction(addItemIcon, tr("Add item"), this);
+	addItemAct->setToolTip(tr("Add an item into the current view."));
+	m_editMenu->addAction(addItemAct);
+
+	QIcon delItemIcon(":/Images/Del.svg");
+	QAction* delItemAct = new QAction(delItemIcon, tr("Delete item"), this);
+	delItemAct->setToolTip(tr("Delete an item from the current view."));
+	m_editMenu->addAction(delItemAct);
+
+	QIcon copyItemIcon(":/Images/Copy.svg");
+	QAction* copyItemAct = new QAction(copyItemIcon, tr("Copy item"), this);
+	copyItemAct->setToolTip(tr("Copy the selected items from the current view."));
+	m_editMenu->addAction(copyItemAct);
+
+	QIcon pasteItemIcon(":/Images/Paste.svg");
+	QAction* pasteItemAct = new QAction(pasteItemIcon, tr("Paste item"), this);
+	pasteItemAct->setToolTip(tr("Paste item from the clipboard into the current view."));
+	m_editMenu->addAction(pasteItemAct);
 
 	// Add help menu
 	m_helpMenu = menuBar()->addMenu(tr("Help"));
@@ -638,6 +661,7 @@ void MainWindow::reinsertMenu()
 	// Reinsert the menu into the menuBar.
 	menuBar()->clear();
 	menuBar()->addMenu(m_fileMenu);
+	menuBar()->addMenu(m_editMenu);
 	if (m_utilityMenu)
 		menuBar()->addMenu(m_utilityMenu);
 	menuBar()->addMenu(m_helpMenu);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -180,21 +180,25 @@ void MainWindow::createMenu()
 	QIcon addItemIcon(":/Images/Add.svg");
 	QAction* addItemAct = new QAction(addItemIcon, tr("Add item"), this);
 	addItemAct->setToolTip(tr("Add an item into the current view."));
+	connect(addItemAct, &QAction::triggered, m_tabAndList, &TabAndList::addItem);
 	m_editMenu->addAction(addItemAct);
 
 	QIcon delItemIcon(":/Images/Del.svg");
 	QAction* delItemAct = new QAction(delItemIcon, tr("Delete item"), this);
 	delItemAct->setToolTip(tr("Delete an item from the current view."));
+	connect(delItemAct, &QAction::triggered, m_tabAndList, &TabAndList::delItem);
 	m_editMenu->addAction(delItemAct);
 
 	QIcon copyItemIcon(":/Images/Copy.svg");
 	QAction* copyItemAct = new QAction(copyItemIcon, tr("Copy item"), this);
 	copyItemAct->setToolTip(tr("Copy the selected items from the current view."));
+	connect(copyItemAct, &QAction::triggered, m_tabAndList, &TabAndList::copyItem);
 	m_editMenu->addAction(copyItemAct);
 
 	QIcon pasteItemIcon(":/Images/Paste.svg");
 	QAction* pasteItemAct = new QAction(pasteItemIcon, tr("Paste item"), this);
 	pasteItemAct->setToolTip(tr("Paste item from the clipboard into the current view."));
+	connect(pasteItemAct, &QAction::triggered, m_tabAndList, &TabAndList::pasteItem);
 	m_editMenu->addAction(pasteItemAct);
 
 	// Add help menu

--- a/src/TabAndList.cpp
+++ b/src/TabAndList.cpp
@@ -962,3 +962,167 @@ void TabAndList::newEmptyList()
     emit newList(ListType::UNKNOWN);
     emit newListFileName(m_filePath);
 }
+
+void TabAndList::addItem()
+{
+    AbstractListView* v = dynamic_cast<AbstractListView*>(m_stackedViews->currentWidget());
+    if (v)
+    {
+        if (v->viewType() == ViewType::UTILITY)
+        {
+            UtilityListView* view = dynamic_cast<UtilityListView*>(v);
+            if (view)
+                view->addItem();
+        }
+        else if (v->viewType() == ViewType::GAME)
+        {
+            GameListView* view = dynamic_cast<GameListView*>(v);
+            if (view)
+                view->addingItem();
+        }
+        else if (v->viewType() == ViewType::MOVIE)
+        {
+            MoviesListView* view = dynamic_cast<MoviesListView*>(v);
+            if (view)
+                view->addingItem();
+        }
+        else if (v->viewType() == ViewType::COMMON)
+        {
+            CommonListView* view = dynamic_cast<CommonListView*>(v);
+            if (view)
+                view->addingItem();
+        }
+        else if (v->viewType() == ViewType::SERIES)
+        {
+            SeriesListView* view = dynamic_cast<SeriesListView*>(v);
+            if (view)
+                view->addingItem();
+        }
+        else if (v->viewType() == ViewType::BOOKS)
+        {
+            BooksListView* view = dynamic_cast<BooksListView*>(v);
+            if (view)
+                view->addingItem();
+        }
+    }
+}
+
+void TabAndList::delItem()
+{
+    AbstractListView* v = dynamic_cast<AbstractListView*>(m_stackedViews->currentWidget());
+    if (v)
+    {
+        if (v->viewType() == ViewType::UTILITY)
+        {
+            UtilityListView* view = dynamic_cast<UtilityListView*>(v);
+            if (view)
+                view->deleteSelectedRows();
+        }
+        else if (v->viewType() == ViewType::GAME)
+        {
+            GameListView* view = dynamic_cast<GameListView*>(v);
+            if (view)
+                view->deletingItems();
+        }
+        else if (v->viewType() == ViewType::MOVIE)
+        {
+            MoviesListView* view = dynamic_cast<MoviesListView*>(v);
+            if (view)
+                view->deletingItems();
+        }
+        else if (v->viewType() == ViewType::COMMON)
+        {
+            CommonListView* view = dynamic_cast<CommonListView*>(v);
+            if (view)
+                view->deletingItems();
+        }
+        else if (v->viewType() == ViewType::SERIES)
+        {
+            SeriesListView* view = dynamic_cast<SeriesListView*>(v);
+            if (view)
+                view->deletingItems();
+        }
+        else if (v->viewType() == ViewType::BOOKS)
+        {
+            BooksListView* view = dynamic_cast<BooksListView*>(v);
+            if (view)
+                view->deletingItems();
+        }
+    }
+}
+
+void TabAndList::copyItem()
+{
+    QWidget* v = m_stackedViews->currentWidget();
+    if (v)
+    {
+        if (m_listType == ListType::GAMELIST)
+        {
+            GameListView* view = dynamic_cast<GameListView*>(v);
+            if (view)
+                view->copy();
+        }
+        else if (m_listType == ListType::MOVIESLIST)
+        {
+            MoviesListView* view = dynamic_cast<MoviesListView*>(v);
+            if (view)
+                view->copy();
+        }
+        else if (m_listType == ListType::COMMONLIST)
+        {
+            CommonListView* view = dynamic_cast<CommonListView*>(v);
+            if (view)
+                view->copy();
+        }
+        else if (m_listType == ListType::SERIESLIST)
+        {
+            SeriesListView* view = dynamic_cast<SeriesListView*>(v);
+            if (view)
+                view->copy();
+        }
+        else if (m_listType == ListType::BOOKSLIST)
+        {
+            BooksListView* view = dynamic_cast<BooksListView*>(v);
+            if (view)
+                view->copy();
+        }
+    }
+}
+
+void TabAndList::pasteItem()
+{
+    QWidget* v = m_stackedViews->currentWidget();
+    if (v)
+    {
+        if (m_listType == ListType::GAMELIST)
+        {
+            GameListView* view = dynamic_cast<GameListView*>(v);
+            if (view)
+                view->paste();
+        }
+        else if (m_listType == ListType::MOVIESLIST)
+        {
+            MoviesListView* view = dynamic_cast<MoviesListView*>(v);
+            if (view)
+                view->paste();
+        }
+        else if (m_listType == ListType::COMMONLIST)
+        {
+            CommonListView* view = dynamic_cast<CommonListView*>(v);
+            if (view)
+                view->paste();
+        }
+        else if (m_listType == ListType::SERIESLIST)
+        {
+            SeriesListView* view = dynamic_cast<SeriesListView*>(v);
+            if (view)
+                view->paste();
+        }
+        else if (m_listType == ListType::BOOKSLIST)
+        {
+            BooksListView* view = dynamic_cast<BooksListView*>(v);
+            if (view)
+                view->paste();
+        }
+    }
+}

--- a/src/TabAndList.cpp
+++ b/src/TabAndList.cpp
@@ -88,7 +88,23 @@ void TabAndList::setupView()
 void TabAndList::tabChanged(int index)
 {
     if (index >= 0 && index < m_stackedViews->count())
+    {
         m_stackedViews->setCurrentIndex(index);
+        AbstractListView* v = dynamic_cast<AbstractListView*>(m_stackedViews->currentWidget());
+        if (v)
+        {
+            emit isAddDelEditVisible(true);
+            if (v->viewType() == ViewType::UTILITY)
+                emit isCopyPasteEditVisible(false);
+            else
+                emit isCopyPasteEditVisible(true);
+        }
+    }
+    else
+    {
+        emit isAddDelEditVisible(false);
+        emit isCopyPasteEditVisible(false);
+    }
 }
 
 void TabAndList::addTable()


### PR DESCRIPTION
Adding an edit menu with the following action :
- Add item
- Deleting item
- Copy item
- Paste item

All the actions are disabled when no view is available. They are all enabled when a list view is viewed. Only add and deleting item actions are enable when an utility view is viewed.