### PR TITLE
Some url containing %1, %2 and %3 were not saved

### DIFF
--- a/src/TableModelBooks.cpp
+++ b/src/TableModelBooks.cpp
@@ -1230,11 +1230,11 @@ void TableModelBooks::setUrl(const QModelIndex& index, const QString& url)
 
         QString statement = QString(
             "UPDATE \"%1\"\n"
-            "SET Url = \"%2\"\n"
-            "WHERE BooksID = %3;")
+            "SET Url = \"%3\"\n"
+            "WHERE BooksID = %2;")
                 .arg(m_tableName)
-                .arg(url)
-                .arg(m_data.at(index.row()).bookID);
+                .arg(m_data.at(index.row()).bookID)
+                .arg(url);
 
 #ifndef NDEBUG
         std::cout << statement.toLocal8Bit().constData() << "\n" << std::endl;

--- a/src/TableModelCommon.cpp
+++ b/src/TableModelCommon.cpp
@@ -1175,11 +1175,11 @@ void TableModelCommon::setUrl(const QModelIndex& index, const QString& url)
 
         QString statement = QString(
             "UPDATE \"%1\"\n"
-            "SET Url = \"%2\"\n"
-            "WHERE CommonID = %3;")
+            "SET Url = \"%3\"\n"
+            "WHERE CommonID = %2;")
                 .arg(m_tableName)
-                .arg(url)
-                .arg(m_data.at(index.row()).commonID);
+                .arg(m_data.at(index.row()).commonID)
+                .arg(url);
 
 #ifndef NDEBUG
         std::cout << statement.toLocal8Bit().constData() << std::endl << std::endl;

--- a/src/TableModelGame.cpp
+++ b/src/TableModelGame.cpp
@@ -1276,11 +1276,11 @@ void TableModelGame::setUrl(const QModelIndex& index, const QString& url)
 
         QString statement = QString(
             "UPDATE \"%1\"\n"
-            "SET Url = \"%2\"\n"
-            "WHERE GameID = %3;")
+            "SET Url = \"%3\"\n"
+            "WHERE GameID = %2;")
                 .arg(m_tableName)
-                .arg(url)
-                .arg(m_data.at(index.row()).gameID);
+                .arg(m_data.at(index.row()).gameID)
+                .arg(url);
         
 #ifndef NDEBUG
         std::cout << statement.toLocal8Bit().constData() << std::endl << std::endl;

--- a/src/TableModelMovies.cpp
+++ b/src/TableModelMovies.cpp
@@ -1277,11 +1277,11 @@ void TableModelMovies::setUrl(const QModelIndex& index, const QString& url)
 
         QString statement = QString(
             "UPDATE \"%1\"\n"
-            "SET Url = \"%2\"\n"
-            "WHERE MovieID = %3;")
+            "SET Url = \"%3\"\n"
+            "WHERE MovieID = %2;")
                 .arg(m_tableName)
-                .arg(url)
-                .arg(m_data.at(index.row()).movieID);
+                .arg(m_data.at(index.row()).movieID)
+                .arg(url);
         
 #ifndef NDEBUG
         std::cout << statement.toLocal8Bit().constData() << std::endl << std::endl;

--- a/src/TableModelSeries.cpp
+++ b/src/TableModelSeries.cpp
@@ -1346,11 +1346,11 @@ void TableModelSeries::setUrl(const QModelIndex& index, const QString& url)
 
         QString statement = QString(
             "UPDATE \"%1\"\n"
-            "SET Url = \"%2\"\n"
-            "WHERE SeriesID = %3;")
+            "SET Url = \"%3\"\n"
+            "WHERE SeriesID = %2;")
                 .arg(m_tableName)
-                .arg(url)
-                .arg(m_data.at(index.row()).serieID);
+                .arg(m_data.at(index.row()).serieID)
+                .arg(url);
 
 #ifndef NDEBUG
         std::cout << statement.toLocal8Bit().constData() << "\n" << std::endl;


### PR DESCRIPTION
In all list, some **urls** containing the sign **%1**, **%2** and/or **%3** were misleading the **QString::arg** function and causing a SQL error.